### PR TITLE
Add Admin Navigation Button + is-admin Endpoint

### DIFF
--- a/MuscleMind/backend/api/auth.routes.js
+++ b/MuscleMind/backend/api/auth.routes.js
@@ -319,6 +319,21 @@ router.post('/new-password', loginMw.newPassword, async(request, response)=>{
     }
 })
 
+router.get('/is-admin', loginMw.requireAuthApi, async(request, response)=>{
+    try {
+        return response.status(200).json({
+            admin: request.session.user.admin
+        });
+    } catch (error) {
+        console.log(error.message)
+        const ip = requestIp.getClientIp(request);
+        await db.log_error('Server error - auth', error.message,ip);
+        return response.status(500).json({
+            message: 'Sikertelen eleres!'
+        });
+    }
+})
+
 //! FUNCTIONS
 async function postEmail(value) {
     try {

--- a/MuscleMind/frontend/html/index.html
+++ b/MuscleMind/frontend/html/index.html
@@ -79,7 +79,7 @@
                 </div>
 
                 <div class="offcanvas-body">
-                    <ul class="nav flex-column d-flex gap-3">
+                    <ul class="nav flex-column d-flex gap-3" id="mobil-nav-list">
 
                         <li class="nav-item selected-navoption">
                             <a class="nav-link"  href="/">Főoldal</a>
@@ -127,7 +127,7 @@
                     
                     <div class="m-2">MENÜ</div>
 
-                    <ul class="nav flex-column d-flex gap-4 align-items-center">
+                    <ul class="nav flex-column d-flex gap-4 align-items-center" id="side-nav-list">
 
                         <!-- Opciók -->
                         <li class="nav-item selected-navoption">

--- a/MuscleMind/frontend/javascript/global.js
+++ b/MuscleMind/frontend/javascript/global.js
@@ -1,6 +1,10 @@
-import { postLogout } from "./api.js";
+import { postLogout, getFetch } from "./api.js";
 
 document.addEventListener('DOMContentLoaded', ()=>{
+    //!admin btn
+    checkAdmin();
+
+    //!logout
     const logoutBtn = document.getElementById('logout');
     logoutBtn.addEventListener('click', ()=>{
         logout();
@@ -13,5 +17,43 @@ async function logout() {
         window.location.href = '/bejelentkezes';
     } catch (error) {
         console.error(error.message)
+    }
+}
+async function checkAdmin() {
+    //? side-nav-list
+    //? mobil-nav-list
+    try {
+        const data = await getFetch('http://127.0.0.1:3000/api/auth/is-admin');
+        const sn = document.getElementById('side-nav-list');
+        const mn = document.getElementById('mobil-nav-list');
+        if(data.admin == 1){
+            // side navconst 
+            const li1 = document.createElement('li');
+            li1.className = 'nav-item';
+            li1.style.border = '1px solid white'
+
+            const a1 = document.createElement('a');
+            a1.className = 'nav-link';
+            a1.href = '/admin';
+            a1.innerHTML = 'Admin';
+
+            li1.appendChild(a1);
+            sn.appendChild(li1);
+
+            // mobil navconst 
+            const li2 = document.createElement('li');
+            li2.className = 'nav-item';
+            li2.style.border = '1px solid white'
+
+            const a2 = document.createElement('a');
+            a2.className = 'nav-link';
+            a2.href = '/admin';
+            a2.innerHTML = 'Admin';
+
+            li2.appendChild(a2);
+            mn.appendChild(li2);
+        }
+    } catch (error) {
+        console.error(error.message);
     }
 }


### PR DESCRIPTION
## Overview
This pull request adds **admin role detection** on the frontend and dynamically displays an **Admin navigation button** for users with admin privileges.

It also introduces a new backend endpoint to support this functionality.

---

## Features

### dmin Detection (Backend)
- New API endpoint:
  - `GET /api/auth/is-admin`
- Returns whether the currently authenticated user has admin privileges
- Used by frontend to control UI access

---

### Dynamic Admin Navigation (Frontend)
- On page load, the app checks if the user is an admin
- If true:
  - An **Admin button** is added to:
    - Sidebar navigation
    - Mobile navigation
- Button links to `/admin`

---

## Implementation Details

- Frontend uses:
  ```javascript
  GET /api/auth/is-admin